### PR TITLE
Fixed the 'spawn npx NOENT' error on Windows

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -89,7 +89,7 @@ function execCmd(cmd, { async = false, cwd = packageRootPath } = {}) {
     childProcess.spawn(
       preparedCmd.cmd,
       preparedCmd.argv,
-      { cwd, stdio: 'inherit' }
+      { cwd, stdio: 'inherit', shell: true }
     );
     return true;
   }


### PR DESCRIPTION
Hi, I was having a bug on Windows, the `init` function worked fine, but when I ran `crana dev` in the created project folder, I had this error:
```bash
$ crana dev
events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: spawn npx ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
    at onErrorNT (internal/child_process.js:362:16)
    at _combinedTickCallback (internal/process/next_tick.js:139:11)
    at process._tickCallback (internal/process/next_tick.js:181:9)
```
Now everything works in Windows, but I can't check other environments.