### PR TITLE
Update README.md, add http server and port listen in index.js, add travis intergration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "iojs"
+  - "7"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,30 @@
 # :sparkles: CReate A Node Application
 ## :battery: A CLI tool to create React + Node apps with just one command (batteries included)
 
-:bulb: To get up and running with an application with a node.js backend and a React frontend, just execute:
+[![Maintainability](https://api.codeclimate.com/v1/badges/e02fed19f69c47fbb3ae/maintainability)](https://codeclimate.com/github/pankaryp/crana/maintainability)
+
+* [Technologies](#technologies)
+* [Quick Start](#quick-start)
+* [Usage](#usage)
+    * [Main Commands](#main-commands)
+    * [Util Commands](#util-commands)
+* [Project Structure](#project-structure)
+* [Known Issues](#known-issues)
+    * [Windows Linux Subsystem](#windows-linux-subsystem)
+* [Contributing](#contributing)
+* [License](#license)
+* [Code of Conduct](#code-of-conduct)
+
+## Technologies
+As soon as you bootstrap a new project, you will have an application running with:
+
+- Node.js backend
+- React.js frontend
+
+Under the hood it uses Webpack, Babel, ESLint and StyleLint with a few other plugins enabling a powerful development workflow, such as server live reload with nodemon and more. All preconfigured out of the box, so that you can focus on the important stuff!
+
+## Quick Start
+:bulb: To get up and running with your first Crana app just execute:
 
 ```bash
 npm i -g crana
@@ -14,18 +37,16 @@ crana init <projectName> [projectFolder]
 
 ...and you are ready to go!
 
-This will equip you with all important tools you're going to need to develop powerful applications, for example __Live reaload__ for the server and the frontend out of the box.
-Webpack, Babel, ESLint, StyleLint, Nodemon etc. etc., all preconfigured out of the box, so that you can focus on the important stuff!
-
 :computer: __Now start developing!__
 ```bash
 crana dev
 ```
-This will fire up the backend and the frontend development server. Just edit files under __src__ and see what happens!
-
-:warning: Crana is in early stage of development and may not meet all your requirements. That's why contributions of any kind are highly appreciated, as the best tools are built by communities!
+This will fire up the frontend and the backend concurrently in development mode.. Just edit files under __src__ and see what happens!
 
 ## Usage
+
+### Main Commands
+
 :star: Create a new crana project.
 ```bash
 crana init <projectName> [projectFolderName]
@@ -33,18 +54,6 @@ crana init <projectName> [projectFolderName]
 :dizzy: Concurrently starts the frontend and the backend in development mode.
 ```bash
 crana dev                                     
-```
-:books: See how many LOC you've already written.
-```bash
-crana count-lines                            
-```
-:mag: Executes eslint and styleling in autofix mode for your client files (src/client + src/shared).
-```bash
-crana lint:client                             
-```
-:mag: Executes eslint in autofix mode for your server files (src/server + src/shared).
-```bash
-crana lint:server                             
 ```
 :satellite: Starts the webpack development server for the frontend.
 ```bash
@@ -63,31 +72,45 @@ crana start
 crana build:client                            
 ```
 
+### Util Commands
+
+:mag: Executes eslint and styleling in autofix mode for your client files (src/client + src/shared).
+```bash
+crana lint:client                             
+```
+:mag: Executes eslint in autofix mode for your server files (src/server + src/shared).
+```bash
+crana lint:server                             
+```
+:books: See how many LOC you've already written.
+```bash
+crana count-lines                            
+```
+
 ## Project structure
 The interesting files for you are all located in the __src__ folder. The src folder has three subfolders:
 - client
 - server
 - shared
 
-As you can imagine, the __client__ folder contains all files for the React frontend application and the __server__ folder contains all files for the node.js backend. The __shared__ folder contains code you would like to share between client and server. This is a good place for e.g. utility functions, domain logic etc.
+As you can imagine, the __client__ folder contains all files for React and the __server__ folder contains all files for Node.js backend. The __shared__ folder contains code you would like to share between client and server. This is a good place for e.g. utility functions, domain logic etc.
 
-Be aware that the server files are not transpiled and thus don't support certain features like ES6 imports. This also the reason why all code in the __shared__ folder must be executable with your current node.js version.
+_NOTE:Be aware that the server files are not transpiled and thus don't support certain features like ES6 imports. This also the reason why all code in the __shared__ folder must be executable with your current node.js version._
 
-## Technologies
-As soon as you bootstrapped a new project, you have an application running with:
+## Known issues
 
-- Node.js backend
-- React for frontend
-
-Under the hood it uses Webpack, Babel, ESLint and StyleLint with a few other plugins enabling a powerful development workflow.
-
-## Known constraints/issues
 ### Windows Linux Subsystem
 If you're using Windows Linux Subsystem, eslint will not immediatly work. You need to edit the path under `.vscode/settings.json`.
 Replace `C:/mnt/c` with `C:` and it should work.
 
 ## Contributing
-Have a look at [CONTRIBUTING.md](CONTRIBUTING.md)
+:warning: Crana is in early stage of development and may not meet all your requirements. That's why contributions of any kind are highly appreciated, as the best tools are built by communities!
+
+Pull requests are always welcome. Please have a look at [CONTRIBUTING.md](CONTRIBUTING.md) and
+open an issue before submitting a pull request.
+
+## License
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
 
 ## Code of conduct
 Have a look at [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,14 @@ As soon as you bootstrap a new project, you will have an application running wit
 Under the hood it uses Webpack, Babel, ESLint and StyleLint with a few other plugins enabling a powerful development workflow, such as server live reload with nodemon and more. All preconfigured out of the box, so that you can focus on the important stuff!
 
 ## Quick Start
-:bulb: To get up and running with your first Crana app just execute:
+:bulb: To get up and running with your first Crana app, fist install Crana globally:
 
 ```bash
 npm i -g crana
+```
+
+Initialize your app
+```bash
 crana init <projectName> [projectFolder]
 ```
 
@@ -47,45 +51,21 @@ This will fire up the frontend and the backend concurrently in development mode.
 
 ### Main Commands
 
-:star: Create a new crana project.
-```bash
-crana init <projectName> [projectFolderName]
-```
-:dizzy: Concurrently starts the frontend and the backend in development mode.
-```bash
-crana dev                                     
-```
-:satellite: Starts the webpack development server for the frontend.
-```bash
-crana dev:client                              
-```
-:bar_chart: Starts the node.js backend in development mode with live-reload.
-```bash
-crana dev:server                              
-```
-:car: Starts the node.js server for production.
-```bash
-crana start                                   
-```
-:blue_car: Creates a production build for the frontend application.
-```bash
-crana build:client                            
-```
+| Command | Description |
+| --- | --- |
+| :star: crana init <projectName> [projectFolderName] | Create a new crana project |
+| :dizzy: crana dev | Concurrently starts the frontend and the backend in development mode |
+| :satellite: crana dev:client | Starts the webpack development server for the frontend |
+| :bar_chart: crana dev:server | Starts the node.js backend in development mode with live-reload |
+| :blue_car: crana build:client | Creates a production build for the frontend application |
 
 ### Util Commands
 
-:mag: Executes eslint and styleling in autofix mode for your client files (src/client + src/shared).
-```bash
-crana lint:client                             
-```
-:mag: Executes eslint in autofix mode for your server files (src/server + src/shared).
-```bash
-crana lint:server                             
-```
-:books: See how many LOC you've already written.
-```bash
-crana count-lines                            
-```
+| Command | Description |
+| --- | --- |
+| :mag: crana lint:client | Executes eslint and styleling in autofix mode for your client files (src/client + src/shared) |
+| :mag: crana lint:server | Executes eslint in autofix mode for your server files (src/server + src/shared) |
+| :books: crana count-lines | See how many LOC you've already written |
 
 ## Project structure
 The interesting files for you are all located in the __src__ folder. The src folder has three subfolders:

--- a/template/src/server/index.js
+++ b/template/src/server/index.js
@@ -1,3 +1,19 @@
+const http = require('http');
+const port = 5000;
+
 const { helloWorld } = require('@shared/util');
 
-console.log('Server started.', helloWorld('Server'));
+const requestHandler = (request, response) => {
+  console.log(request.url);
+  response.end('Server started on port 5000', helloWorld('Server'));
+};
+
+const server = http.createServer(requestHandler);
+
+server.listen(port, (err) => {
+  if (err) {
+    return console.log('something bad happened', err);
+  }
+
+  console.log(`Server is listening on port ${port}`);
+});


### PR DESCRIPTION
**Changes made: **

1. README.md update
2. Add http server and port listen in index.js
3. Add code climate and travis cl intergration

I am not sure if this is a right addition, but i found very annoying the fact that when i was running "_crana dev:server_", it wasnt exaclty clear in what port the server is listening. 
I didnt bother to add a specific framework binding like "_const app = express()" - "app.listen('3000', console.log('server is running');_ ", because i understand that crana is a generic way to create a node-react app with whatever node framework you want.

Also i wasnt exaclty sure, how you generate the crana template and how you can add this in the source code. 

Furthermore I updated the README.md and made it more appealing to read.